### PR TITLE
Fix build

### DIFF
--- a/arch/riscv/cpu/k230/Makefile
+++ b/arch/riscv/cpu/k230/Makefile
@@ -58,3 +58,4 @@ EXTRA_CFLAGS += -I$(srctree)/arch/$(ARCH)/cpu/k230/puf_fw/pufs_hmac
 EXTRA_CFLAGS += -I$(srctree)/arch/$(ARCH)/cpu/k230/puf_fw/pufs_ka
 EXTRA_CFLAGS += -I$(srctree)/arch/$(ARCH)/cpu/k230/puf_fw/pufs_rt
 EXTRA_CFLAGS += -I$(srctree)/arch/$(ARCH)/cpu/k230/puf_fw/pufs_sm2
+EXTRA_CFLAGS += -I$(srctree)/board/canaan/common

--- a/arch/riscv/cpu/k230/cpu.c
+++ b/arch/riscv/cpu/k230/cpu.c
@@ -34,6 +34,7 @@
 #include <spl.h>
 #include <asm/cache.h>
 #include <linux/delay.h>
+#include <k230_board_common.h>
 #include "platform.h"
 
 static inline void improving_cpu_performance(void)

--- a/arch/riscv/cpu/k230/dram.c
+++ b/arch/riscv/cpu/k230/dram.c
@@ -7,8 +7,10 @@
 #include <common.h>
 #include <fdtdec.h>
 #include <init.h>
+#include <linux/delay.h>
 #include <linux/sizes.h>
 #include <asm/io.h>
+#include <k230_board_common.h>
 
 DECLARE_GLOBAL_DATA_PTR;
 
@@ -33,20 +35,20 @@ DECLARE_GLOBAL_DATA_PTR;
 static void pd_pll(uint32_t pll_ctl,uint32_t pll_stat)
 {
 int rdata;
-   writel(0x10001,pll_ctl);
-   rdata=readl(pll_stat);
+   writel(0x10001, (volatile void __iomem *)pll_ctl);
+   rdata=readl((const volatile void __iomem *)pll_stat);
    while( (rdata&0x30) != 0x0){ 
-        rdata=readl(pll_stat);
+        rdata=readl((const volatile void __iomem *)pll_stat);
    }
 }
 
 static void init_pll(uint32_t pll_ctl,uint32_t pll_stat)
 {
    int rdata;
-   writel(0x20002,pll_ctl);
-   rdata=readl(pll_stat);
+   writel(0x20002, (volatile void __iomem *)pll_ctl);
+   rdata=readl((const volatile void __iomem *)pll_stat);
    while( (rdata & 0x30) != 0x20){ 
-        rdata=readl(pll_stat);
+        rdata=readl((const volatile void __iomem *)pll_stat);
    }
 }
 
@@ -55,8 +57,8 @@ static uint32_t cfg_pll(int fb_div,int ref_div,int out_div,int pllx_cfg0,int pll
   int pll_sta;
   int wdata,rdata;
   pd_pll(pllx_ctl,pllx_stat);
-  writel(( (fb_div/4) | 0x20000),pllx_cfg1 ); //for minimum long term jitter
-  writel(( (fb_div & 0x1fff) | ( (ref_div & 0x3f) << 16 ) | ( (out_div & 0xf) << 24) ),pllx_cfg0 );
+  writel(( (fb_div/4) | 0x20000), (volatile void __iomem *)pllx_cfg1 ); //for minimum long term jitter
+  writel(( (fb_div & 0x1fff) | ( (ref_div & 0x3f) << 16 ) | ( (out_div & 0xf) << 24) ), (volatile void __iomem *)pllx_cfg0 );
   init_pll(pllx_ctl,pllx_stat);
 }
 

--- a/arch/riscv/cpu/k230/puf_fw/pufs_common/pufs_internal.c
+++ b/arch/riscv/cpu/k230/puf_fw/pufs_common/pufs_internal.c
@@ -34,7 +34,7 @@ uint8_t pufs_buffer[BUFFER_SIZE];
  ****************************************************************************/
 void hardlock_config(pufs_lock_t lock_cfg)
 {
-    void *lock_base_addr = 0x911040b8;
+    void *lock_base_addr = (void *)0x911040b8;
 
     switch(lock_cfg)
     {

--- a/arch/riscv/cpu/k230/puf_fw/pufs_hmac/pufs_hmac.c
+++ b/arch/riscv/cpu/k230/puf_fw/pufs_hmac/pufs_hmac.c
@@ -24,6 +24,7 @@
 #include "pufs_ka_internal.h"
 #include "pufs_dma_internal.h"
 #include <common.h>
+#include <cpu_func.h>
 #include "platform.h"
 #include "pufs_ecp.h"
 #pragma GCC push_options
@@ -63,7 +64,7 @@ static pufs_status_t __hmac_ctx_update(pufs_dgst_st* md,
     cb_dma_write_config_0(false, false, false);
     cb_dma_write_data_block_config(hmac_ctx->start ? false : true, last, true, true, 0);
 
-    flush_dcache_range((uint64_t *)msg, msg+msglen); // //csi_dcache_clean_range
+    flush_dcache_range((unsigned long)msg, (unsigned long)msg+msglen); // //csi_dcache_clean_range
     cb_dma_write_rwcfg(NULL, msg, msglen);
 
     cb_dma_write_key_config_0(hmac_ctx->keytype,

--- a/arch/riscv/cpu/k230/puf_fw/pufs_sp38a/pufs_sp38a.c
+++ b/arch/riscv/cpu/k230/puf_fw/pufs_sp38a/pufs_sp38a.c
@@ -169,9 +169,9 @@ static pufs_status_t __sp38a_ctx_update(uint8_t* outbuf,
     cb_dma_write_config_0(false, false, false);
     cb_dma_write_data_block_config(sp38a_ctx->start ? false : true, last, true, true, 0);
 
-    flush_dcache_range((uint64_t *)inbuf, inbuf+inlen);// //csi_dcache_clean_range
-    invalidate_dcache_range((uint64_t *)outbuf, outbuf+inlen);
-    //csi_dcache_clean_invalid_range((uint64_t *)outbuf, inlen);
+    flush_dcache_range((unsigned long)inbuf, (unsigned long)inbuf+inlen);// //csi_dcache_clean_range
+    invalidate_dcache_range((unsigned long)outbuf, (unsigned long)outbuf+inlen);
+    //csi_dcache_clean_invalid_range((unsigned long)outbuf, (unsigned long)inlen);
     cb_dma_write_rwcfg(outbuf, inbuf, inlen);
 
     if ((check = cb_sp38a_prepare(sp38a_ctx)) != SUCCESS)

--- a/arch/riscv/cpu/k230/puf_fw/pufs_sp38d/pufs_sp38d.c
+++ b/arch/riscv/cpu/k230/puf_fw/pufs_sp38d/pufs_sp38d.c
@@ -24,6 +24,7 @@
 #include "pufs_sp38d_internal.h"
 #include "pufs_ka_internal.h"
 #include "pufs_dma_internal.h"
+#include "cpu_func.h"
 #include "platform.h"
 
 #pragma GCC push_options
@@ -228,14 +229,14 @@ static pufs_status_t __sp38d_ctx_update(uint8_t* out,
     cb_dma_write_data_block_config(sp38d_ctx->start ? false : true, last, true, true, 0);
 
     cb_dma_write_rwcfg(out, in, inlen);
-    flush_dcache_range((uint64_t *)in, in+inlen);  //csi_dcache_clean_range
+    flush_dcache_range((unsigned long)in, (unsigned long)in+inlen);  //csi_dcache_clean_range
     
     if ((check = cb_sp38d_prepare(out, inlen)) != SUCCESS)
         return check;
 
     if (out != NULL)
     {
-        invalidate_dcache_range((uint64_t *)out, out+inlen);//csi_dcache_clean_invalid_range
+        invalidate_dcache_range((unsigned long)out, (unsigned long)out+inlen);//csi_dcache_clean_invalid_range
     }
     cb_dma_write_start();
     while (cb_dma_check_busy_status(&val32));

--- a/board/canaan/common/Makefile
+++ b/board/canaan/common/Makefile
@@ -62,4 +62,3 @@ EXTRA_CFLAGS += -I$(srctree)/arch/$(ARCH)/cpu/k230/puf_fw/pufs_ecp
 EXTRA_CFLAGS += -I$(srctree)/arch/$(ARCH)/cpu/k230/puf_fw/pufs_sm2
 EXTRA_CFLAGS += -I$(srctree)/arch/$(ARCH)/cpu/k230/puf_fw/pufs_sp38a
 EXTRA_CFLAGS += -I$(srctree)/arch/$(ARCH)/cpu/k230/puf_fw/pufs_sp38d
-

--- a/board/canaan/common/k230_board_common.h
+++ b/board/canaan/common/k230_board_common.h
@@ -24,6 +24,9 @@
  */
 #ifndef __K230_BOARD_H__
 #define __K230_BOARD_H__
+
+#include "sysctl.h"
+
 //uboo使用的是 128M@128M  0x8000000---0x100000000
 //假设：密文32MB；明文32M,解压缩后32M, ----
 /*

--- a/board/canaan/common/k230_spl.c
+++ b/board/canaan/common/k230_spl.c
@@ -82,38 +82,38 @@ static void device_disable(void)
     uint32_t value;
 
     // disable ai power
-    if (readl(0x9110302c) & 0x2)
-        writel(0x30001, 0x91103028);
+    if (readl((const volatile void __iomem *)0x9110302c) & 0x2)
+        writel(0x30001, (volatile void __iomem *)0x91103028);
     // disable vpu power
-    if (readl(0x91103080) & 0x2)
-        writel(0x30001, 0x9110307c);
+    if (readl((const volatile void __iomem *)0x91103080) & 0x2)
+        writel(0x30001, (volatile void __iomem *)0x9110307c);
     // disable dpu power
-    if (readl(0x9110310c) & 0x2)
-        writel(0x30001, 0x91103108);
+    if (readl((const volatile void __iomem *)0x9110310c) & 0x2)
+        writel(0x30001, (volatile void __iomem *)0x91103108);
     // disable disp power
-    if (readl(0x91103040) & 0x2)
-        writel(0x30001, 0x9110303c);
+    if (readl((const volatile void __iomem *)0x91103040) & 0x2)
+        writel(0x30001, (volatile void __iomem *)0x9110303c);
     // check disable status
     value = 1000000;
-    while ((!(readl(0x9110302c) & 0x1) || !(readl(0x91103080) & 0x1) ||
-        !(readl(0x9110310c) & 0x1) || !(readl(0x91103040) & 0x1)) && value)
+    while ((!(readl((const volatile void __iomem *)0x9110302c) & 0x1) || !(readl((const volatile void __iomem *)0x91103080) & 0x1) ||
+        !(readl((const volatile void __iomem *)0x9110310c) & 0x1) || !(readl((const volatile void __iomem *)0x91103040) & 0x1)) && value)
         value--;
     // disable ai clk
-    value = readl(0x91100008);
+    value = readl((const volatile void __iomem *)0x91100008);
     value &= ~((1 << 0));
-    writel(value, 0x91100008);
+    writel(value, (volatile void __iomem *)0x91100008);
     // disable vpu clk
-    value = readl(0x9110000c);
+    value = readl((const volatile void __iomem *)0x9110000c);
     value &= ~((1 << 0));
-    writel(value, 0x9110000c);
+    writel(value, (volatile void __iomem *)0x9110000c);
     // disable dpu clk
-    value = readl(0x91100070);
+    value = readl((const volatile void __iomem *)0x91100070);
     value &= ~((1 << 0));
-    writel(value, 0x91100070);
+    writel(value, (volatile void __iomem *)0x91100070);
     // disable mclk
-    value = readl(0x9110006c);
+    value = readl((const volatile void __iomem *)0x9110006c);
     value &= ~((1 << 0) | (1 << 1) | (1 << 2));
-    writel(value, 0x9110006c);
+    writel(value, (volatile void __iomem *)0x9110006c);
 }
 
 __weak void quick_boot_board_init(void)
@@ -130,7 +130,8 @@ int spl_board_init_f(void)
     g_bootmod = sysctl_boot_get_boot_mode();
 
     record_boot_time_info_to_sram("ds");
-    ddr_init_training();
+    //ddr_init_training();
+    dram_init();
     record_boot_time_info_to_sram("dd");
     /* Clear the BSS. */
     //record_boot_time_info_to_sram("bs");

--- a/common/spl/spl_spinand.c
+++ b/common/spl/spl_spinand.c
@@ -34,7 +34,7 @@ static int spi_load_image_os(struct spl_image_info *spl_image,
 
 	lenth = sizeof(*header);
 	/* Read for a header, parse or error out. */
-	nand_read(flash, CONFIG_SYS_SPI_KERNEL_OFFS, &lenth,
+	nand_read((struct mtd_info *)flash, CONFIG_SYS_SPI_KERNEL_OFFS, &lenth,
 		       (void *)header);
 
 	if (image_get_magic(header) != IH_MAGIC)
@@ -45,12 +45,12 @@ static int spi_load_image_os(struct spl_image_info *spl_image,
 		return err;
 
 	lenth = spl_image->size;
-	nand_read(flash, CONFIG_SYS_SPI_KERNEL_OFFS,
+	nand_read((struct mtd_info *)flash, CONFIG_SYS_SPI_KERNEL_OFFS,
 		       &lenth, (void *)spl_image->load_addr);
 
 	lenth = CONFIG_SYS_SPI_ARGS_SIZE;
 	/* Read device tree. */
-	nand_read(flash, CONFIG_SYS_SPI_ARGS_OFFS,
+	nand_read((struct mtd_info *)flash, CONFIG_SYS_SPI_ARGS_OFFS,
 		       &lenth,
 		       (void *)CONFIG_SYS_SPL_ARGS_ADDR);
 
@@ -64,7 +64,7 @@ static ulong spl_spi_fit_read(struct spl_load_info *load, ulong sector,
 	struct spi_flash *flash = load->dev;
 	ulong ret;
 
-	ret = nand_read(flash, sector, &count, buf);
+	ret = nand_read((struct mtd_info *)flash, sector, &count, buf);
 	if (!ret)
 		return count;
 	else
@@ -130,7 +130,7 @@ static int spl_spinand_load_image(struct spl_image_info *spl_image,
 	{
 		lenth = sizeof(*header);
 		/* Load u-boot, mkimage header is 64 bytes. */
-		err = nand_read(flash, payload_offs, &lenth,
+		err = nand_read((struct mtd_info *)flash, payload_offs, &lenth,
 				     (void *)header);
 		if (err) {
 			debug("%s: Failed to read from SPI flash (err=%d)\n",
@@ -141,7 +141,7 @@ static int spl_spinand_load_image(struct spl_image_info *spl_image,
 		lenth = roundup(fdt_totalsize(header), 4);
 		if (IS_ENABLED(CONFIG_SPL_LOAD_FIT_FULL) &&
 		    image_get_magic(header) == FDT_MAGIC) {
-			err = nand_read(flash, payload_offs,
+			err = nand_read((struct mtd_info *)flash, payload_offs,
 					     &lenth,
 					     (void *)CONFIG_SYS_LOAD_ADDR);
 			if (err)
@@ -177,7 +177,7 @@ static int spl_spinand_load_image(struct spl_image_info *spl_image,
 			if (err)
 				return err;
 			lenth = spl_image->size;
-			err = nand_read(flash, payload_offs + spl_image->offset,
+			err = nand_read((struct mtd_info *)flash, payload_offs + spl_image->offset,
 					     &lenth,
 					     (void *)spl_image->load_addr);
 		}

--- a/drivers/pinctrl/pinctrl-single.c
+++ b/drivers/pinctrl/pinctrl-single.c
@@ -103,14 +103,14 @@ static unsigned int single_read(struct udevice *dev, fdt_addr_t reg)
 
 	switch (pdata->width) {
 	case 8:
-		return readb(reg);
+		return readb((const volatile void __iomem *)reg);
 	case 16:
-		return readw(reg);
+		return readw((const volatile void __iomem *)reg);
 	default: /* 32 bits */
-		return readl(reg);
+		return readl((const volatile void __iomem *)reg);
 	}
 
-	return readb(reg);
+	return readb((const volatile void __iomem *)reg);
 }
 
 static void single_write(struct udevice *dev, unsigned int val, fdt_addr_t reg)
@@ -119,13 +119,13 @@ static void single_write(struct udevice *dev, unsigned int val, fdt_addr_t reg)
 
 	switch (pdata->width) {
 	case 8:
-		writeb(val, reg);
+		writeb(val, (volatile void __iomem *)reg);
 		break;
 	case 16:
-		writew(val, reg);
+		writew(val, (volatile void __iomem *)reg);
 		break;
 	default: /* 32 bits */
-		writel(val, reg);
+		writel(val, (volatile void __iomem *)reg);
 	}
 }
 

--- a/drivers/spi/designware_spi.c
+++ b/drivers/spi/designware_spi.c
@@ -1055,17 +1055,17 @@ static int dw_spi_exec_op(struct spi_slave *slave, const struct spi_mem_op *op)
 		{
 			axiawlen.axiawlen.awlen = axi_len;
 			dw_write(priv, DW_SPI_AXIAWLEN, axiawlen.data);
-			flush_dcache_range(buffer, buffer + op->data.nbytes);
-			invalidate_dcache_range(buffer, buffer + op->data.nbytes);
+			flush_dcache_range((unsigned long)buffer, (unsigned long)(buffer + op->data.nbytes));
+			invalidate_dcache_range((unsigned long)buffer, (unsigned long)(buffer + op->data.nbytes));
 		}
 		else
 		{
 			axiarlen.axiarlen.arlen = axi_len;
 			dw_write(priv, DW_SPI_AXIARLEN, axiarlen.data);
-			flush_dcache_range(buffer, buffer + op->data.nbytes);
+			flush_dcache_range((unsigned long)buffer, (unsigned long)(buffer + op->data.nbytes));
 		}
 
-		dw_write(priv, DW_SPI_AXIAR0, buffer);
+		dw_write(priv, DW_SPI_AXIAR0, (unsigned int)buffer);
 	}
 
 	external_cs_manage(slave->dev, false);

--- a/drivers/usb/host/dwc2.c
+++ b/drivers/usb/host/dwc2.c
@@ -95,7 +95,7 @@ static void init_fslspclksel(struct dwc2_core_regs *regs)
 #endif
 
 #ifdef DWC2_ULPI_FS_LS
-	uint32_t hwcfg2 = readl(&regs->ghwcfg2);
+	uint32_t hwcfg2 = readl((const volatile void __iomem *)&regs->ghwcfg2);
 	uint32_t hval = (ghwcfg2 & DWC2_HWCFG2_HS_PHY_TYPE_MASK) >>
 			DWC2_HWCFG2_HS_PHY_TYPE_OFFSET;
 	uint32_t fval = (ghwcfg2 & DWC2_HWCFG2_FS_PHY_TYPE_MASK) >>
@@ -122,7 +122,7 @@ static void dwc_otg_flush_tx_fifo(struct udevice *dev,
 	int ret;
 
 	writel(DWC2_GRSTCTL_TXFFLSH | (num << DWC2_GRSTCTL_TXFNUM_OFFSET),
-	       &regs->grstctl);
+	       (volatile void __iomem *)&regs->grstctl);
 	ret = wait_for_bit_le32(&regs->grstctl, DWC2_GRSTCTL_TXFFLSH,
 				false, 1000, false);
 	if (ret)
@@ -142,7 +142,7 @@ static void dwc_otg_flush_rx_fifo(struct udevice *dev,
 {
 	int ret;
 
-	writel(DWC2_GRSTCTL_RXFFLSH, &regs->grstctl);
+	writel(DWC2_GRSTCTL_RXFFLSH, (volatile void __iomem *)&regs->grstctl);
 	ret = wait_for_bit_le32(&regs->grstctl, DWC2_GRSTCTL_RXFFLSH,
 				false, 1000, false);
 	if (ret)
@@ -168,13 +168,13 @@ static void dwc_otg_core_reset(struct udevice *dev,
 		dev_info(dev, "%s: Timeout!\n", __func__);
 
 	/* Core Soft Reset */
-	writel(DWC2_GRSTCTL_CSFTRST, &regs->grstctl);
+	writel(DWC2_GRSTCTL_CSFTRST, (volatile void __iomem *)&regs->grstctl);
 	ret = wait_for_bit_le32(&regs->grstctl, DWC2_GRSTCTL_CSFTRST_DONE,
 				true, 1000, false);
 	if (ret)
 		dev_info(dev, "%s: Timeout!\n", __func__);
 	udelay(100);
-	writel(0, &regs->grstctl);
+	writel(0, (volatile void __iomem *)&regs->grstctl);
 	/*
 	 * Wait for core to come out of reset.
 	 * NOTE: This long sleep is _very_ important, otherwise the core will
@@ -256,7 +256,7 @@ static void dwc_otg_core_host_init(struct udevice *dev,
 	int i, ret, num_channels;
 
 	/* Restart the Phy Clock */
-	writel(0, &regs->pcgcctl);
+	writel(0, (volatile void __iomem *)&regs->pcgcctl);
 
 	/* Initialize Host Configuration Register */
 	init_fslspclksel(regs);
@@ -266,16 +266,16 @@ static void dwc_otg_core_host_init(struct udevice *dev,
 
 	/* Configure data FIFO sizes */
 #ifdef DWC2_ENABLE_DYNAMIC_FIFO
-	if (readl(&regs->ghwcfg2) & DWC2_HWCFG2_DYNAMIC_FIFO) {
+	if (readl((const volatile void __iomem *)&regs->ghwcfg2) & DWC2_HWCFG2_DYNAMIC_FIFO) {
 		/* Rx FIFO */
-		writel(DWC2_HOST_RX_FIFO_SIZE, &regs->grxfsiz);
+		writel(DWC2_HOST_RX_FIFO_SIZE, (volatile void __iomem *)&regs->grxfsiz);
 
 		/* Non-periodic Tx FIFO */
 		nptxfifosize |= DWC2_HOST_NPERIO_TX_FIFO_SIZE <<
 				DWC2_FIFOSIZE_DEPTH_OFFSET;
 		nptxfifosize |= DWC2_HOST_RX_FIFO_SIZE <<
 				DWC2_FIFOSIZE_STARTADDR_OFFSET;
-		writel(nptxfifosize, &regs->gnptxfsiz);
+		writel(nptxfifosize, (volatile void __iomem *)&regs->gnptxfsiz);
 
 		/* Periodic Tx FIFO */
 		ptxfifosize |= DWC2_HOST_PERIO_TX_FIFO_SIZE <<
@@ -283,12 +283,12 @@ static void dwc_otg_core_host_init(struct udevice *dev,
 		ptxfifosize |= (DWC2_HOST_RX_FIFO_SIZE +
 				DWC2_HOST_NPERIO_TX_FIFO_SIZE) <<
 				DWC2_FIFOSIZE_STARTADDR_OFFSET;
-		writel(ptxfifosize, &regs->hptxfsiz);
+		writel(ptxfifosize, (volatile void __iomem *)&regs->hptxfsiz);
 	}
 #endif
-	gdfifocfg = readl(&regs->ghwcfg3) >> 16;
+	gdfifocfg = readl((const volatile void __iomem *)&regs->ghwcfg3) >> 16;
 	epinfobase = DWC2_HOST_RX_FIFO_SIZE+DWC2_HOST_NPERIO_TX_FIFO_SIZE+DWC2_HOST_PERIO_TX_FIFO_SIZE;
-	writel((epinfobase<<DWC2_GDFIFOCFG_EPINFOBASE_OFFSET) | (gdfifocfg & DWC2_GDFIFOCFG_GDFIFOCFG_MASK), &regs->gdfifocfg);
+	writel((epinfobase<<DWC2_GDFIFOCFG_EPINFOBASE_OFFSET) | (gdfifocfg & DWC2_GDFIFOCFG_GDFIFOCFG_MASK), (volatile void __iomem *)&regs->gdfifocfg);
 
 	/* Clear Host Set HNP Enable in the OTG Control Register */
 	clrbits_le32(&regs->gotgctl, DWC2_GOTGCTL_HSTSETHNPEN);
@@ -298,7 +298,7 @@ static void dwc_otg_core_host_init(struct udevice *dev,
 	dwc_otg_flush_rx_fifo(dev, regs);
 
 	/* Flush out any leftover queued requests. */
-	num_channels = readl(&regs->ghwcfg2);
+	num_channels = readl((const volatile void __iomem *)&regs->ghwcfg2);
 	num_channels &= DWC2_HWCFG2_NUM_HOST_CHAN_MASK;
 	num_channels >>= DWC2_HWCFG2_NUM_HOST_CHAN_OFFSET;
 	num_channels += 1;
@@ -320,13 +320,13 @@ static void dwc_otg_core_host_init(struct udevice *dev,
 	}
 
 	/* Turn on the vbus power. */
-	if (readl(&regs->gintsts) & DWC2_GINTSTS_CURMODE_HOST) {
-		hprt0 = readl(&regs->hprt0);
+	if (readl((const volatile void __iomem *)&regs->gintsts) & DWC2_GINTSTS_CURMODE_HOST) {
+		hprt0 = readl((const volatile void __iomem *)&regs->hprt0);
 		hprt0 &= ~(DWC2_HPRT0_PRTENA | DWC2_HPRT0_PRTCONNDET);
 		hprt0 &= ~(DWC2_HPRT0_PRTENCHNG | DWC2_HPRT0_PRTOVRCURRCHNG);
 		if (!(hprt0 & DWC2_HPRT0_PRTPWR)) {
 			hprt0 |= DWC2_HPRT0_PRTPWR;
-			writel(hprt0, &regs->hprt0);
+			writel(hprt0, (volatile void __iomem *)&regs->hprt0);
 		}
 
         // kendryte
@@ -334,9 +334,9 @@ static void dwc_otg_core_host_init(struct udevice *dev,
         #define USB1_TEST_CTL3 (0x9158509cU)
         #define USB_DMPULLDOWN0 	(1<<8)
         #define USB_DPPULLDOWN0 	(1<<9)
-        u32 usb_test_ctl3 = readl((regs == 0x91500000)?USB0_TEST_CTL3:USB1_TEST_CTL3);
+        u32 usb_test_ctl3 = readl((regs == 0x91500000)?(const volatile void __iomem *)USB0_TEST_CTL3:(const volatile void __iomem *)USB1_TEST_CTL3);
         usb_test_ctl3 |= (USB_DMPULLDOWN0 | USB_DPPULLDOWN0);
-        writel(usb_test_ctl3, (regs == 0x91500000)?USB0_TEST_CTL3:USB1_TEST_CTL3);
+        writel(usb_test_ctl3, (regs == 0x91500000)?(volatile void __iomem *)USB0_TEST_CTL3:(volatile void __iomem *)USB1_TEST_CTL3);
 	}
 
 	if (dev)
@@ -358,7 +358,7 @@ static void dwc_otg_core_init(struct udevice *dev)
 	uint8_t brst_sz = DWC2_DMA_BURST_SIZE;
 
 	/* Common Initialization */
-	usbcfg = readl(&regs->gusbcfg);
+	usbcfg = readl((const volatile void __iomem *)&regs->gusbcfg);
 
 	/* Program the ULPI External VBUS bit if needed */
 	if (priv->ext_vbus) {
@@ -377,7 +377,7 @@ static void dwc_otg_core_init(struct udevice *dev)
 #else
 	usbcfg &= ~DWC2_GUSBCFG_TERM_SEL_DL_PULSE;
 #endif
-	writel(usbcfg, &regs->gusbcfg);
+	writel(usbcfg, (volatile void __iomem *)&regs->gusbcfg);
 
 	/* Reset the Controller */
 	dwc_otg_core_reset(dev, regs);
@@ -399,7 +399,7 @@ static void dwc_otg_core_init(struct udevice *dev)
 	 * Also do this on HNP Dev/Host mode switches (done in dev_init
 	 * and host_init).
 	 */
-	if (readl(&regs->gintsts) & DWC2_GINTSTS_CURMODE_HOST)
+	if (readl((const volatile void __iomem *)&regs->gintsts) & DWC2_GINTSTS_CURMODE_HOST)
 		init_fslspclksel(regs);
 
 #ifdef DWC2_I2C_ENABLE
@@ -436,16 +436,16 @@ static void dwc_otg_core_init(struct udevice *dev)
 #endif
 	}
 
-	writel(usbcfg, &regs->gusbcfg);
+	writel(usbcfg, (volatile void __iomem *)&regs->gusbcfg);
 
 	/* Reset after setting the PHY parameters */
 	dwc_otg_core_reset(dev, regs);
 #endif
 
-	usbcfg = readl(&regs->gusbcfg);
+	usbcfg = readl((const volatile void __iomem *)&regs->gusbcfg);
 	usbcfg &= ~(DWC2_GUSBCFG_ULPI_FSLS | DWC2_GUSBCFG_ULPI_CLK_SUS_M);
 #ifdef DWC2_ULPI_FS_LS
-	uint32_t hwcfg2 = readl(&regs->ghwcfg2);
+	uint32_t hwcfg2 = readl((const volatile void __iomem *)&regs->ghwcfg2);
 	uint32_t hval = (ghwcfg2 & DWC2_HWCFG2_HS_PHY_TYPE_MASK) >>
 			DWC2_HWCFG2_HS_PHY_TYPE_OFFSET;
 	uint32_t fval = (ghwcfg2 & DWC2_HWCFG2_FS_PHY_TYPE_MASK) >>
@@ -458,10 +458,10 @@ static void dwc_otg_core_init(struct udevice *dev)
 	if (priv->hnp_srp_disable)
 		usbcfg |= DWC2_GUSBCFG_FORCEHOSTMODE;
 
-	writel(usbcfg, &regs->gusbcfg);
+	writel(usbcfg, (volatile void __iomem *)&regs->gusbcfg);
 
 	/* Program the GAHBCFG Register. */
-	switch (readl(&regs->ghwcfg2) & DWC2_HWCFG2_ARCHITECTURE_MASK) {
+	switch (readl((const volatile void __iomem *)&regs->ghwcfg2) & DWC2_HWCFG2_ARCHITECTURE_MASK) {
 	case DWC2_HWCFG2_ARCHITECTURE_SLAVE_ONLY:
 		break;
 	case DWC2_HWCFG2_ARCHITECTURE_EXT_DMA:
@@ -484,7 +484,7 @@ static void dwc_otg_core_init(struct udevice *dev)
 		break;
 	}
 
-	writel(ahbcfg, &regs->gahbcfg);
+	writel(ahbcfg, (volatile void __iomem *)&regs->gahbcfg);
 
 	/* Program the capabilities in GUSBCFG Register */
 	usbcfg = 0;
@@ -525,10 +525,10 @@ static void dwc_otg_hc_init(struct dwc2_core_regs *regs, uint8_t hc_num,
 	 * Program the HCCHARn register with the endpoint characteristics
 	 * for the current transfer.
 	 */
-	writel(hcchar, &hc_regs->hcchar);
+	writel(hcchar, (volatile void __iomem *)&hc_regs->hcchar);
 
 	/* Program the HCSPLIT register, default to no SPLIT */
-	writel(0, &hc_regs->hcsplt);
+	writel(0, (volatile void __iomem *)&hc_regs->hcsplt);
 }
 
 static void dwc_otg_hc_init_split(struct dwc2_hc_regs *hc_regs,
@@ -541,7 +541,7 @@ static void dwc_otg_hc_init_split(struct dwc2_hc_regs *hc_regs,
 	hcsplt |= hub_port << DWC2_HCSPLT_PRTADDR_OFFSET;
 
 	/* Program the HCSPLIT register for SPLITs */
-	writel(hcsplt, &hc_regs->hcsplt);
+	writel(hcsplt, (volatile void __iomem *)&hc_regs->hcsplt);
 }
 
 /*
@@ -573,7 +573,7 @@ static int dwc_otg_submit_rh_msg_in_status(struct dwc2_core_regs *regs,
 		len = 4;
 		break;
 	case USB_RECIP_OTHER | USB_TYPE_CLASS:
-		hprt0 = readl(&regs->hprt0);
+		hprt0 = readl((const volatile void __iomem *)&regs->hprt0);
 		if (hprt0 & DWC2_HPRT0_PRTCONNSTS)
 			port_status |= USB_PORT_STAT_CONNECTION;
 		if (hprt0 & DWC2_HPRT0_PRTENA)
@@ -844,8 +844,8 @@ int wait_for_chhltd(struct dwc2_hc_regs *hc_regs, uint32_t *sub, u8 *toggle)
 	if (ret)
 		return ret;
 
-	hcint = readl(&hc_regs->hcint);
-	hctsiz = readl(&hc_regs->hctsiz);
+	hcint = readl((const volatile void __iomem *)&hc_regs->hcint);
+	hctsiz = readl((const volatile void __iomem *)&hc_regs->hctsiz);
 	*sub = (hctsiz & DWC2_HCTSIZ_XFERSIZE_MASK) >>
 		DWC2_HCTSIZ_XFERSIZE_OFFSET;
 	*toggle = (hctsiz & DWC2_HCTSIZ_PID_MASK) >> DWC2_HCTSIZ_PID_OFFSET;
@@ -883,7 +883,7 @@ static int transfer_chunk(struct dwc2_hc_regs *hc_regs, void *aligned_buffer,
 	writel((xfer_len << DWC2_HCTSIZ_XFERSIZE_OFFSET) |
 	       (num_packets << DWC2_HCTSIZ_PKTCNT_OFFSET) |
 	       (*pid << DWC2_HCTSIZ_PID_OFFSET),
-	       &hc_regs->hctsiz);
+	       (volatile void __iomem *)&hc_regs->hctsiz);
 
 	if (xfer_len) {
 		if (in) {
@@ -900,10 +900,10 @@ static int transfer_chunk(struct dwc2_hc_regs *hc_regs, void *aligned_buffer,
 		}
 	}
 
-	writel(phys_to_bus((unsigned long)aligned_buffer), &hc_regs->hcdma);
+	writel(phys_to_bus((unsigned long)aligned_buffer), (volatile void __iomem *)&hc_regs->hcdma);
 
 	/* Clear old interrupt conditions for this host channel. */
-	writel(0x3fff, &hc_regs->hcint);
+	writel(0x3fff, (volatile void __iomem *)&hc_regs->hcint);
 
 	/* Set host channel enable after all other setup is complete. */
 	clrsetbits_le32(&hc_regs->hcchar, DWC2_HCCHAR_MULTICNT_MASK |
@@ -972,7 +972,7 @@ int chunk_msg(struct dwc2_priv *priv, struct usb_device *dev,
 	if (dev->speed != USB_SPEED_HIGH) {
 		uint8_t hub_addr;
 		uint8_t hub_port;
-		uint32_t hprt0 = readl(&regs->hprt0);
+		uint32_t hprt0 = readl((const volatile void __iomem *)&regs->hprt0);
 		if ((hprt0 & DWC2_HPRT0_PRTSPD_MASK) ==
 		     DWC2_HPRT0_PRTSPD_HIGH) {
 			usb_find_usb2_hub_address_port(dev, &hub_addr,
@@ -1004,7 +1004,7 @@ int chunk_msg(struct dwc2_priv *priv, struct usb_device *dev,
 			clrbits_le32(&hc_regs->hcsplt, DWC2_HCSPLT_COMPSPLT);
 
 		if (eptype == DWC2_HCCHAR_EPTYPE_INTR) {
-			int uframe_num = readl(&host_regs->hfnum);
+			int uframe_num = readl((const volatile void __iomem *)&host_regs->hfnum);
 			if (!(uframe_num & 0x1))
 				odd_frame = 1;
 		}
@@ -1013,13 +1013,13 @@ int chunk_msg(struct dwc2_priv *priv, struct usb_device *dev,
 				     in, (char *)buffer + done, num_packets,
 				     xfer_len, &actual_len, odd_frame);
 
-		hcint = readl(&hc_regs->hcint);
+		hcint = readl((const volatile void __iomem *)&hc_regs->hcint);
 		if (complete_split) {
 			stop_transfer = 0;
 			if (hcint & DWC2_HCINT_NYET) {
 				ret = 0;
 				int frame_num = DWC2_HFNUM_MAX_FRNUM &
-						readl(&host_regs->hfnum);
+						readl((const volatile void __iomem *)&host_regs->hfnum);
 				if (((frame_num - ssplit_frame_num) &
 				    DWC2_HFNUM_MAX_FRNUM) > 4)
 					ret = -EAGAIN;
@@ -1028,7 +1028,7 @@ int chunk_msg(struct dwc2_priv *priv, struct usb_device *dev,
 		} else if (do_split) {
 			if (hcint & DWC2_HCINT_ACK) {
 				ssplit_frame_num = DWC2_HFNUM_MAX_FRNUM &
-						   readl(&host_regs->hfnum);
+						   readl((const volatile void __iomem *)&host_regs->hfnum);
 				ret = 0;
 				complete_split = 1;
 			}
@@ -1048,8 +1048,8 @@ int chunk_msg(struct dwc2_priv *priv, struct usb_device *dev,
 	 */
 	} while (((done < len) && !stop_transfer) || complete_split);
 
-	writel(0, &hc_regs->hcintmsk);
-	writel(0xFFFFFFFF, &hc_regs->hcint);
+	writel(0, (volatile void __iomem *)&hc_regs->hcintmsk);
+	writel(0xFFFFFFFF, (volatile void __iomem *)&hc_regs->hcint);
 
 	dev->status = 0;
 	dev->act_len = done;
@@ -1202,7 +1202,7 @@ static int dwc2_init_common(struct udevice *dev, struct dwc2_priv *priv)
 	if (ret)
 		return ret;
 
-	snpsid = readl(&regs->gsnpsid);
+	snpsid = readl((const volatile void __iomem *)&regs->gsnpsid);
 	dev_info(dev, "Core Release: %x.%03x\n",
 		 snpsid >> 12 & 0xf, snpsid & 0xfff);
 
@@ -1251,7 +1251,7 @@ static int dwc2_init_common(struct udevice *dev, struct dwc2_priv *priv)
 	 * is started (the bus is scanned) and  fixes the USB detection
 	 * problems with some problematic USB keys.
 	 */
-	if (readl(&regs->gintsts) & DWC2_GINTSTS_CURMODE_HOST)
+	if (readl((const volatile void __iomem *)&regs->gintsts) & DWC2_GINTSTS_CURMODE_HOST)
 		mdelay(1000);
 
 	printf("USB DWC2\n");
@@ -1443,7 +1443,7 @@ static int dwc2_usb_probe(struct udevice *dev)
 	int ret;
 
 	bus_priv->desc_before_addr = true;
-	writel(0x1, 0x91108030);
+	writel(0x1, (volatile void __iomem *)0x91108030);
 
 	ret = dwc2_clk_init(dev);
 	if (ret)


### PR DESCRIPTION
## Summary by Sourcery

Address build errors by applying correct pointer casts for I/O and cache operations, adding necessary includes across drivers, board and firmware code, and updating build include paths.

Bug Fixes:
- Cast register and memory-mapped I/O pointers to volatile void __iomem in readl/writel and related calls to satisfy type requirements
- Cast buffer pointers to unsigned long in flush_dcache_range and invalidate_dcache_range calls to match function signatures
- Cast flash device pointer to struct mtd_info in nand_read calls for SPI NAND loader

Enhancements:
- Add missing header includes (linux/delay.h, asm/io.h, cpu_func.h, k230_board_common.h) in dram, CPU and PUF firmware code
- Replace deprecated ddr_init_training with dram_init in SPL board initialization
- Include sysctl.h in k230_board_common.h

Build:
- Add board common include path to arch/riscv and board Canaan Makefiles